### PR TITLE
Add PHP 8 return type annotations

### DIFF
--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -83,6 +83,7 @@ class Response implements ArrayAccess
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->response[$offset]);
@@ -91,6 +92,7 @@ class Response implements ArrayAccess
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->response[$offset];
@@ -99,6 +101,7 @@ class Response implements ArrayAccess
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->response[$offset] = $value;
@@ -107,6 +110,7 @@ class Response implements ArrayAccess
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->response[$offset]);


### PR DESCRIPTION
This fix allows to support PHP 5.6, 7.x and 8.x, but it will not work with PHP 9.

Correct return types can later be added when support for PHP 9 is desired but it will need to drop support for PHP 5 and 7.

fixes #1